### PR TITLE
Read CLI defaults from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ curl -v -x 127.0.0.1:8080 http://www.example.com
 ```
 
 Proxy listens on `127.0.0.1:8080` by default. Use `-L` (or `--listen-address`) CLI option to change this.
+
+## Environment variables
+
+| Variable | Description |
+| - | - |
+| `ETC_HOSTS_PROXY_DEBUG` | Enable debug mode |
+| `ETC_HOSTS_PROXY_LOG_LEVEL` | Set the logging level [`trace`, `debug`, `info`, `warn`, `error`] |
+| `ETC_HOSTS_PROXY_MODE` | Mode to start proxy in (`http` or `socks5`) |
+| `ETC_HOSTS_PROXY_LISTEN_ADDRESS` | [`<host>`]:`<port>` to listen for proxy requests on |
+| `ETC_HOSTS_PROXY_HOSTS_LIST` | comma-separated list of `<host>=<ip>` pairs to resolve `<host>` to `<ip>` |

--- a/run.go
+++ b/run.go
@@ -31,9 +31,16 @@ func newRunCommand() *cobra.Command {
 			executableName,
 		),
 	}
-	runCommand.Flags().StringToStringP("hosts", "H", map[string]string{}, "<host>=<ip> pairs to resolve <host> to <ip>")
-	runCommand.Flags().StringP("mode", "M", "http", "Mode to start proxy in (http or socks5)")
-	runCommand.Flags().StringP("listen-address", "L", "127.0.0.1:8080", "[<host>]:<port> to listen for proxy requests on")
+
+	runCommand.Flags().StringToStringP("hosts", "H",
+		GetEnvStrMap("ETC_HOSTS_PROXY_HOSTS_LIST"),
+		"<host>=<ip> pairs to resolve <host> to <ip> (ETC_HOSTS_PROXY_HOSTS_LIST)")
+	runCommand.Flags().StringP("mode", "M",
+		GetEnvWithDefault("ETC_HOSTS_PROXY_MODE", "http"),
+		"Mode to start proxy in (http or socks5) (ETC_HOSTS_PROXY_MODE)")
+	runCommand.Flags().StringP("listen-address", "L",
+		GetEnvWithDefault("ETC_HOSTS_PROXY_LISTEN_ADDRESS", "127.0.0.1:8080"),
+		"[<host>]:<port> to listen for proxy requests on (ETC_HOSTS_PROXY_LISTEN_ADDRESS)")
 	return runCommand
 }
 


### PR DESCRIPTION
Now CLI read its defaults from the environment variables. This is mostly to simplify the docker experience.
See README for the variables list